### PR TITLE
fix: Make twenty-mcp work as a claude.ai Custom Connector

### DIFF
--- a/src/auth/clerk-client.ts
+++ b/src/auth/clerk-client.ts
@@ -47,36 +47,64 @@ export class ClerkClient {
     if (!this.enabled) {
       return { valid: false, error: 'Authentication is not enabled' };
     }
-    
+
     try {
-      // Remove 'Bearer ' prefix if present
       const cleanToken = token.replace(/^Bearer\s+/i, '');
-      
-      // Verify the session using the session ID from the token
-      // First, we need to decode the JWT to get the session ID
+
+      // Path 1: Clerk session JWT — three-part JWT with a `sid` claim pointing
+      // at an active Clerk session. This is the shape Clerk's frontend SDKs issue.
       const tokenParts = cleanToken.split('.');
-      if (tokenParts.length !== 3) {
-        return { valid: false, error: 'Invalid token format' };
+      if (tokenParts.length === 3) {
+        try {
+          const payload = JSON.parse(Buffer.from(tokenParts[1], 'base64url').toString());
+          if (payload.sid) {
+            const session = await this.clerk.sessions.getSession(payload.sid);
+            if (!session || session.status !== 'active') {
+              return { valid: false, error: 'Invalid or inactive session' };
+            }
+            return {
+              valid: true,
+              userId: session.userId,
+              sessionId: session.id,
+            };
+          }
+        } catch {
+          // Not a Clerk session JWT; fall through to OAuth validation.
+        }
       }
-      
-      // Decode the payload (base64url decode)
-      const payload = JSON.parse(Buffer.from(tokenParts[1], 'base64url').toString());
-      
-      if (!payload.sid) {
-        return { valid: false, error: 'No session ID in token' };
+
+      // Path 2: OAuth 2.0 access token (issued to third-party clients via
+      // authorization_code grant, e.g. claude.ai's MCP connector). These are
+      // not Clerk sessions; validate by calling Clerk's userinfo endpoint.
+      const clerkDomain = process.env.CLERK_DOMAIN;
+      if (!clerkDomain) {
+        return { valid: false, error: 'CLERK_DOMAIN not configured' };
       }
-      
-      // Verify the session exists and is active
-      const session = await this.clerk.sessions.getSession(payload.sid);
-      
-      if (!session || session.status !== 'active') {
-        return { valid: false, error: 'Invalid or inactive session' };
+
+      const userinfoResponse = await fetch(`https://${clerkDomain}/oauth/userinfo`, {
+        headers: { Authorization: `Bearer ${cleanToken}` },
+      });
+
+      if (!userinfoResponse.ok) {
+        return {
+          valid: false,
+          error: `OAuth token rejected by Clerk (HTTP ${userinfoResponse.status})`,
+        };
       }
-      
+
+      const userInfo = (await userinfoResponse.json()) as {
+        user_id?: string;
+        sub?: string;
+      };
+      const userId = userInfo.user_id || userInfo.sub;
+      if (!userId) {
+        return { valid: false, error: 'No user ID in OAuth userinfo response' };
+      }
+
       return {
         valid: true,
-        userId: session.userId,
-        sessionId: session.id,
+        userId,
+        sessionId: 'oauth-access-token',
       };
     } catch (error) {
       console.error('Token validation error:', error);

--- a/src/auth/middleware.ts
+++ b/src/auth/middleware.ts
@@ -63,12 +63,17 @@ export class AuthMiddleware {
   }
   
   private sendUnauthorized(res: ServerResponse, message: string): void {
+    // Advertise the protected resource metadata URL so MCP clients can discover
+    // the authorization server without needing the bare path (RFC 9728).
+    const serverUrl = process.env.MCP_SERVER_URL || 'http://localhost:3000';
+    const resourceMetadata = `${serverUrl}/.well-known/oauth-protected-resource/mcp`;
     res.writeHead(401, {
       'Content-Type': 'application/json',
-      'WWW-Authenticate': 'Bearer realm="Twenty MCP Server"',
+      'WWW-Authenticate': `Bearer realm="Twenty MCP Server", resource_metadata="${resourceMetadata}"`,
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-      'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+      'Access-Control-Allow-Headers': 'Authorization, Content-Type, Mcp-Session-Id, MCP-Protocol-Version, Last-Event-ID',
+      'Access-Control-Expose-Headers': 'WWW-Authenticate',
     });
     res.end(JSON.stringify({
       error: 'unauthorized',

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -4,6 +4,7 @@ import { createServer } from 'node:http';
 import { randomUUID } from 'node:crypto';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { TwentyClient } from './client/twenty-client.js';
 import { registerPersonTools, registerCompanyTools, registerTaskTools, registerOpportunityTools } from './tools/index.js';
 import { WellKnownRoutes } from './routes/well-known.js';
@@ -34,7 +35,12 @@ async function main() {
     keyStorage = getKeyStorageService();
     apiKeyRoutes = new ApiKeyRoutes();
   }
-  
+
+  // Map of MCP session ID -> live transport. Sticky sessions are required by
+  // the Streamable HTTP spec: the initialize request creates a session, and
+  // follow-up calls (tools/list, tool invocations) reuse the same transport.
+  const transports: Record<string, StreamableHTTPServerTransport> = {};
+
   // Parse configuration from multiple sources
   async function parseConfig(url: string, userId?: string) {
     const urlObj = new URL(url, `http://localhost:${port}`);
@@ -147,97 +153,106 @@ async function main() {
           return; // Auth middleware already sent response
         }
       }
-      // Parse configuration from query parameters
-      const userId = authReq.auth?.userId;
-      const config = await parseConfig(req.url, userId);
-      
-      if (!config.apiKey) {
-        // If authenticated but no API key stored
-        if (authEnabled && userId) {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({
-            error: 'No API key configured',
-            error_description: 'Please configure your Twenty API key first'
-          }));
-          return;
-        }
-        // For non-authenticated requests
-        res.writeHead(400, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({
-          error: 'Missing required apiKey parameter'
-        }));
-        return;
-      }
 
-      // Create MCP server with Twenty client
-      const server = new McpServer({
-        name: 'twenty-mcp-server',
-        version: '1.0.0',
-      }, {
-        capabilities: {
-          tools: {},
-          experimental: {
-            authentication: {
-              type: 'oauth2',
-              required: authEnabled && process.env.REQUIRE_AUTH === 'true',
-              enabled: authEnabled,
-              discoveryEndpoints: authEnabled ? {
-                protectedResource: '/.well-known/oauth-protected-resource',
-                authorizationServer: '/.well-known/oauth-authorization-server'
-              } : undefined
-            }
-          }
-        }
-      });
-
-      const client = new TwentyClient({
-        apiKey: config.apiKey,
-        baseUrl: config.baseUrl,
-      });
-
-      // Register tools
-      registerPersonTools(server, client);
-      registerCompanyTools(server, client);
-      registerTaskTools(server, client);
-      registerOpportunityTools(server, client);
-
-      // Create streamable HTTP transport
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => randomUUID(),
-      });
-
-      // Connect server to transport
-      await server.connect(transport);
-
-      // Parse request body for POST requests
+      // Read the body up front on POST so we can detect initialize requests
+      // before deciding whether to reuse a session or create a new one.
       let body: any = undefined;
       if (req.method === 'POST') {
         const chunks: Buffer[] = [];
-        req.on('data', (chunk) => chunks.push(chunk));
-        req.on('end', async () => {
+        for await (const chunk of req) {
+          chunks.push(chunk as Buffer);
+        }
+        const bodyText = Buffer.concat(chunks).toString();
+        if (bodyText.trim()) {
           try {
-            const bodyText = Buffer.concat(chunks).toString();
-            if (bodyText.trim()) {
-              body = JSON.parse(bodyText);
-            }
-            await transport.handleRequest(req, res, body);
+            body = JSON.parse(bodyText);
           } catch (error) {
             console.error('Error parsing request body:', error);
             res.writeHead(400, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({ error: 'Invalid JSON in request body' }));
+            return;
           }
-        });
-      } else {
-        // Handle GET/DELETE requests
-        await transport.handleRequest(req, res, body);
+        }
       }
+
+      const sessionIdHeader = req.headers['mcp-session-id'];
+      const sessionId = Array.isArray(sessionIdHeader) ? sessionIdHeader[0] : sessionIdHeader;
+
+      let transport: StreamableHTTPServerTransport;
+
+      if (sessionId && transports[sessionId]) {
+        // Continue an existing MCP session.
+        transport = transports[sessionId];
+      } else if (!sessionId && req.method === 'POST' && isInitializeRequest(body)) {
+        // New session: validate config, build a server + tools, spin up a transport.
+        const userId = authReq.auth?.userId;
+        const config = await parseConfig(req.url!, userId);
+
+        if (!config.apiKey) {
+          if (authEnabled && userId) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              error: 'No API key configured',
+              error_description: 'Please configure your Twenty API key first',
+            }));
+            return;
+          }
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Missing required apiKey parameter' }));
+          return;
+        }
+
+        const server = new McpServer(
+          { name: 'twenty-mcp-server', version: '1.0.0' },
+          { capabilities: { tools: {} } },
+        );
+
+        const client = new TwentyClient({
+          apiKey: config.apiKey,
+          baseUrl: config.baseUrl,
+        });
+
+        registerPersonTools(server, client);
+        registerCompanyTools(server, client);
+        registerTaskTools(server, client);
+        registerOpportunityTools(server, client);
+
+        transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          onsessioninitialized: (newSessionId: string) => {
+            transports[newSessionId] = transport;
+          },
+        });
+
+        transport.onclose = () => {
+          if (transport.sessionId) {
+            delete transports[transport.sessionId];
+          }
+        };
+
+        await server.connect(transport);
+      } else {
+        // Request references a session we don't have, or isn't an initialize.
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          error: 'Invalid MCP request',
+          error_description: sessionId
+            ? 'Unknown or expired session ID; send an initialize request to start a new session'
+            : 'Missing session ID; send an initialize request to start a new session',
+        }));
+        return;
+      }
+
+      await transport.handleRequest(req, res, body);
     } catch (error) {
       console.error('Error handling request:', error);
-      res.writeHead(500, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({
-        error: 'Internal server error',
-        message: error instanceof Error ? error.message : 'Unknown error'
-      }));
+      if (!res.headersSent) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          error: 'Internal server error',
+          message: error instanceof Error ? error.message : 'Unknown error',
+        }));
+      }
     }
   });
 

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -106,8 +106,13 @@ async function main() {
       return;
     }
     
-    // Handle OAuth discovery endpoints
-    if (req.url === '/.well-known/oauth-protected-resource') {
+    // Handle OAuth discovery endpoints.
+    // MCP clients following the Protected Resource Metadata spec fetch
+    // /.well-known/oauth-protected-resource/<resource-path> (e.g. .../mcp).
+    if (
+      req.url === '/.well-known/oauth-protected-resource' ||
+      req.url === '/.well-known/oauth-protected-resource/mcp'
+    ) {
       if (!authEnabled) {
         res.writeHead(404, { 'Content-Type': 'text/plain' });
         res.end('Not Found');

--- a/src/routes/well-known.ts
+++ b/src/routes/well-known.ts
@@ -20,7 +20,7 @@ export class WellKnownRoutes {
       bearer_methods_supported: ['header'],
       resource_documentation: 'https://github.com/jezweb/twenty-mcp',
       resource_signing_alg_values_supported: ['RS256'],
-      scopes_supported: ['twenty:read', 'twenty:write'],
+      scopes_supported: ['openid', 'profile', 'email'],
     };
     
     res.writeHead(200, {
@@ -41,7 +41,7 @@ export class WellKnownRoutes {
       token_endpoint: `https://${this.clerkDomain}/oauth/token`,
       jwks_uri: `https://${this.clerkDomain}/.well-known/jwks.json`,
       registration_endpoint: `https://${this.clerkDomain}/oauth/register`,
-      scopes_supported: ['openid', 'profile', 'email', 'twenty:read', 'twenty:write'],
+      scopes_supported: ['openid', 'profile', 'email', 'offline_access'],
       response_types_supported: ['code'],
       grant_types_supported: ['authorization_code', 'refresh_token'],
       code_challenge_methods_supported: ['S256'],

--- a/src/routes/well-known.ts
+++ b/src/routes/well-known.ts
@@ -61,8 +61,9 @@ export class WellKnownRoutes {
   async handleOptions(req: IncomingMessage, res: ServerResponse): Promise<void> {
     res.writeHead(200, {
       'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+      'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+      'Access-Control-Allow-Headers': 'Authorization, Content-Type, Mcp-Session-Id, MCP-Protocol-Version, Last-Event-ID',
+      'Access-Control-Expose-Headers': 'Mcp-Session-Id',
       'Access-Control-Max-Age': '86400',
     });
     res.end();

--- a/src/routes/well-known.ts
+++ b/src/routes/well-known.ts
@@ -10,9 +10,12 @@ export class WellKnownRoutes {
   }
   
   async handleProtectedResource(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    // RFC 9728 - OAuth 2.0 Protected Resource Metadata
+    // RFC 9728 - OAuth 2.0 Protected Resource Metadata.
+    // Clients may request the bare path or the per-resource path (e.g. /mcp).
+    // Describe the /mcp resource in both cases since it's the only protected resource we expose.
+    const resource = `${this.serverUrl}/mcp`;
     const metadata = {
-      resource: this.serverUrl,
+      resource,
       authorization_servers: [`https://${this.clerkDomain}`],
       bearer_methods_supported: ['header'],
       resource_documentation: 'https://github.com/jezweb/twenty-mcp',


### PR DESCRIPTION
Hi! We deployed twenty-mcp and tried to connect it as a [Custom Connector in claude.ai](https://support.anthropic.com/en/articles/11175166-getting-started-with-custom-connectors-using-remote-mcp) and hit a cascade of five bugs before it worked end-to-end. All five fixes are small, atomic commits — please cherry-pick selectively if you'd prefer.

## The five bugs, in order of failure

### 1. CORS preflight blocks POST /mcp (`12e2196`)
`WellKnownRoutes.handleOptions` is the catch-all `OPTIONS` handler for every route, but it only advertised `Allow-Methods: GET, OPTIONS` and `Allow-Headers: Authorization, Content-Type`. Browsers doing a preflight for `POST /mcp` — and for MCP's `Mcp-Session-Id` / `MCP-Protocol-Version` / `Last-Event-ID` headers — get blocked.

Fix: advertise `POST, DELETE` and the MCP-spec headers; expose `Mcp-Session-Id` on responses.

### 2. Per-resource metadata path 404s (`41dffb0`)
claude.ai follows [RFC 9728 Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728): for the resource at `/mcp`, it fetches `/.well-known/oauth-protected-resource/mcp` (not the bare path). The server only handled the bare path.

Also, the 401 `WWW-Authenticate` header didn't include a `resource_metadata="..."` pointer, so clients that fall back to reading that header had nothing to discover.

Fix: route the `/mcp` variant to the same handler; return `resource: <server>/mcp` in the body; add `resource_metadata` to `WWW-Authenticate`.

### 3. Clerk rejects the advertised `twenty:*` scopes (`1a0a5f6`)
The OAuth metadata advertises `scopes_supported: [..., 'twenty:read', 'twenty:write']`. When claude.ai does Dynamic Client Registration (RFC 7591) with those scopes, Clerk responds:

> `invalid_client_metadata`: Invalid scope requested. Allowed scopes: email, profile, public_metadata, private_metadata, openid, offline_access

claude.ai aborts with `step=start_error` before the user sees the sign-in page. The custom scopes weren't being enforced anywhere in the server anyway (the Twenty API key is a single server-side secret), so they were decorative.

Fix: drop `twenty:read` / `twenty:write` from the metadata; advertise `openid, profile, email, offline_access`.

### 4. OAuth access tokens fail validation (`02c49c2`)
`ClerkClient.validateToken` decodes a JWT, looks for a `sid` claim, and calls `clerk.sessions.getSession(sid)`. That works for Clerk's **session JWTs** (issued by the frontend SDK), but claude.ai sends an **OAuth 2.0 access token** obtained via the authorization_code grant — which has no `sid`. Validation returns `"No session ID in token"` → 401 → claude.ai reports "Your account was authorized but the integration rejected the credentials."

Fix: when the token isn't a parseable session JWT, call Clerk's `/oauth/userinfo` endpoint. If Clerk accepts the token, take `user_id || sub` from the response. Session JWTs keep the original fast path.

### 5. MCP sessions don't persist across requests (`dd029d7`)
This is the biggest one. The `/mcp` handler creates a **new** `McpServer` + `StreamableHTTPServerTransport` on **every** request, each with a fresh `randomUUID` session ID. MCP's Streamable HTTP protocol requires sticky sessions: `initialize` returns a session ID, and the client sends it back as `Mcp-Session-Id` on every follow-up call (`tools/list`, tool invocations).

Without a session map, follow-up requests hit a fresh transport whose session ID doesn't match the client's header, so `tools/list` silently returned nothing and claude.ai showed "This connector has no tools available." — with zero new log lines, since the transport was happy to run but had nothing to say.

Fix: the canonical pattern — a `transports: Record<sessionId, StreamableHTTPServerTransport>` map.
- Known session ID → reuse that transport
- No session ID + `isInitializeRequest(body)` → build a new server, register tools, create a transport, wire `onsessioninitialized` / `onclose` to maintain the map
- Otherwise → 400 with a useful error

Also dropped the `experimental.authentication` capability payload from the `initialize` response — OAuth discovery already happens via `/.well-known`, and that capability shape isn't in the MCP spec.

## Context

I maintain a fork at [Cypher-Capital/twenty-mcp](https://github.com/Cypher-Capital/twenty-mcp) where all five fixes are landed and running in production via Render, successfully serving claude.ai's MCP connector. Happy to split this into five separate PRs if you'd prefer that review cadence — just say the word.

Thanks for the solid server — even pre-fixes, the OAuth / Clerk scaffolding is great.

🤖 Generated with [Claude Code](https://claude.com/claude-code)